### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 README
 =======
 
-This repository contains a collection of Internet Drafts addressing token binding.
+This repository contains _editors' drafts_ of the [IETF Tokbind Working Group](https://datatracker.ietf.org/wg/tokbind/documents/)'s Internet Drafts.
 
-HTML versions of the current drafts are here:
+These links yield rendered versions of these editors' drafts:
 
 - [draft-ietf-tokbind-protocol-06](http://xml2rfc.ietf.org/cgi-bin/xml2rfc.cgi?modeAsFormat=html/ascii&url=https://raw.githubusercontent.com/TokenBinding/Internet-Drafts/master/draft-ietf-tokbind-protocol-06.xml)
 - [draft-ietf-tokbind-https-03](http://xml2rfc.ietf.org/cgi-bin/xml2rfc.cgi?modeAsFormat=html/ascii&url=https://raw.githubusercontent.com/TokenBinding/Internet-Drafts/master/draft-ietf-tokbind-https-03.xml)
 - [draft-ietf-tokbind-negotiation-02](http://xml2rfc.ietf.org/cgi-bin/xml2rfc.cgi?modeAsFormat=html/ascii&url=https://raw.githubusercontent.com/TokenBinding/Internet-Drafts/master/draft-ietf-tokbind-negotiation-02.xml)
+
+
+[Click here](https://datatracker.ietf.org/wg/tokbind/documents/) if you are looking for [the current "officially published" tokbind Internet-Drafts](https://datatracker.ietf.org/wg/tokbind/documents/).


### PR DESCRIPTION
the current readme doesn't make it clear that the repo contains what are effectively "editors' drafts", nor does it link back to the tokbind wg page. this update addresses both. 
