### PR TITLE
minor change to HTTPSTB intro to say that the header field value is *a base64url encoded* TokenBindingMessage

### DIFF
--- a/draft-ietf-tokbind-https-03.xml
+++ b/draft-ietf-tokbind-https-03.xml
@@ -270,7 +270,7 @@
       (commonly referred to as HTTPS).</t>
       <t>HTTP clients establish a Token Binding ID with a server by
       including a special HTTP header field in HTTP requests. The HTTP
-      header field value is a TokenBindingMessage.</t>
+      header field value is a base64url encoded TokenBindingMessage.</t>
       <t>TokenBindingMessages allow clients to establish multiple
       Token Binding IDs with the server, by including multiple
       TokenBinding structures in the TokenBindingMessage. By default,


### PR DESCRIPTION
bikeshedding a bit I know but it is true and maybe helpful to some readers
