### PR TITLE
HTTPSTB-editorial: resolves various issues

### DIFF
--- a/draft-ietf-tokbind-https-04.xml
+++ b/draft-ietf-tokbind-https-04.xml
@@ -286,7 +286,15 @@
       server than the one that the TokenBindingMessage is sent
       to. This is useful in federation scenarios.</t>
 
-      <section title="Requirements Language">
+      <section title="Terminology">
+        <t>The following terms are defined in 
+        <xref target="I-D.ietf-tokbind-protocol"/>: 
+        TokenBinding, 
+        TokenBindingID ("Token Binding ID"),
+        TokenBindingMessage, 
+        TokenBindingType
+        </t>
+
         <t>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
         "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
         document are to be interpreted as described in <xref target="RFC2119" />.</t>
@@ -296,7 +304,8 @@
     <section title="The Sec-Token-Binding Header Field">
       <t>Once a client and server have negotiated the Token Binding
       Protocol with HTTP/1.1 or HTTP/2 (see <xref
-      target="I-D.ietf-tokbind-protocol">The Token Binding Protocol</xref>), clients
+      target="I-D.ietf-tokbind-protocol"/> and <xref
+      target="I-D.ietf-tokbind-negotiation"/>), clients
       MUST include the Sec-Token-Binding header field in their HTTP requests. The ABNF 
       of the Sec-Token-Binding header field is (in <xref target="RFC7230"/> style, see also <xref target="RFC7231"/> Section 8.3):
       </t>
@@ -307,8 +316,8 @@
       <t>The header field name is "Sec-Token-Binding", and 
       EncodedTokenBindingMessage is a base64url encoding 
       (see <xref target="RFC4648"/> Section 5) 
-      of the TokenBindingMessage as defined in the <xref
-      target="I-D.ietf-tokbind-protocol">TokenBindingProtocol</xref>.</t>
+      of the TokenBindingMessage as defined in <xref
+      target="I-D.ietf-tokbind-protocol"/>.</t>
       
       <t>For example:</t>
       <figure><artwork><![CDATA[
@@ -318,9 +327,9 @@
 
       <t>The TokenBindingMessage MUST contain a TokenBinding with
       TokenBindingType provided_token_binding, which MUST be signed
-      with the Token Binding key used by the client for connections
+      with the Token Binding private key used by the client for connections
       between itself and the server that the HTTP request is sent to
-      (clients use different Token Binding keys for different
+      (clients use different Token Binding key pairs for different
       servers). The Token Binding ID established by this TokenBinding
       is called a <spanx style="emph">Provided Token Binding
       ID</spanx>.</t>

--- a/draft-ietf-tokbind-https-04.xml
+++ b/draft-ietf-tokbind-https-04.xml
@@ -221,22 +221,21 @@
     <abstract>
       <t>This document describes a collection of mechanisms that allow
       HTTP servers to cryptographically bind authentication tokens
-      (such as cookies and OAuth tokens) to a <xref
-      target="RFC5246">TLS</xref> connection.</t>
+      (such as cookies and OAuth tokens) to <xref
+      target="RFC5246">TLS</xref> connections.</t>
 
-      <t>We describe both <spanx style="emph">first-party</spanx> as
-      well as <spanx style="emph">federated</spanx> scenarios. In a
-      first-party scenario, an HTTP server issues a security token
-      (such as a cookie) to a client, and expects the client to send
-      the security token back to the server at a later time in order
-      to authenticate. Binding the token to the TLS connection between
-      client and server protects the security token from theft, and
-      ensures that the security token can only be used by the client
-      that it was issued to.</t>
+      <t>We describe both <spanx style="emph">first-party</spanx> and
+      <spanx style="emph">federated</spanx> scenarios. In a first-party
+      scenario, an HTTP server is able to cryptographically bind the security
+      tokens it issues to a client, and which the client
+      subsequently returns to the server, to the TLS connection 
+      between the client and server. Such bound security tokens are 
+      protected from misuse since the server can generally detect if they are
+      replayed inappropriately, e.g., over other TLS connections.</t>
 
       <t>Federated token bindings, on the other hand, allow servers to
-      cryptographically bind security tokens to a <xref
-      target="RFC5246">TLS</xref> connection that the client has with
+      cryptographically bind security tokens to a TLS
+      connection that the client has with
       a <spanx style="emph">different</spanx> server than the one
       issuing the token.</t>
 
@@ -250,7 +249,7 @@
       <t><xref target="I-D.ietf-tokbind-protocol">The Token Binding Protocol</xref>
       defines a Token Binding ID for a TLS connection between a client
       and a server. The Token Binding ID of a TLS connection is
-      related to a private key that the client proves possession of to
+      related to a private key, that the client proves possession of to
       the server, and is long-lived (i.e., subsequent TLS connections
       between the same client and server have the same Token Binding
       ID). When issuing a security token (e.g. an HTTP cookie or an
@@ -317,14 +316,22 @@
         ]]></artwork></figure>
       
 
-      <t>The TokenBindingMessage MUST contain a TokenBinding with
-      TokenBindingType provided_token_binding, which MUST be signed
+      <t>The TokenBindingMessage MUST contain one TokenBinding structure 
+      with TokenBindingType of provided_token_binding, which MUST be signed
       with the Token Binding private key used by the client for connections
       between itself and the server that the HTTP request is sent to
       (clients use different Token Binding key pairs for different
       servers). The Token Binding ID established by this TokenBinding
       is called a <spanx style="emph">Provided Token Binding
       ID</spanx>.</t>
+      
+      <t>The TokenBindingMessage MAY also contain one TokenBinding structure
+      with TokenBindingType of referred_token_binding, as specified in
+      <xref target="sctn-http-redir"/>. In addition to the latter,
+      or rather than the latter, the TokenBindingMessage 
+      MAY contain other TokenBinding structures. This is use case-specific, 
+      and such use cases are outside the scope of this
+      specification.</t>
 
       <t>In HTTP/2, the client SHOULD use <xref
       target="RFC7541">Header
@@ -332,6 +339,21 @@
       header field in subsequent HTTP requests.</t>
     </section>
 
+    <section title="First-party Use Cases">
+      <t>In a first-party use case, an HTTP server issues a security token
+      such as a cookie (or similar) to a client, and expects the client to return
+      the security token at a later time, e.g., in order
+      to authenticate. Binding the security token to the TLS connection between
+      client and server protects the security token from misuse 
+      since the server can detect if the security token is
+      replayed inappropriately, e.g., over other TLS connections.</t>
+      
+      <t>See <xref target="I-D.ietf-tokbind-protocol"/> Section 6 for 
+      general guidance regarding binding of security tokens and their 
+      subsequent validation.</t>
+      
+    </section>
+    
     <section title="Federation Use Cases">
 
       <section title="Introduction">
@@ -426,7 +448,7 @@
     document to specify similar mechanisms for flows that do not include such redirects.</t>
       </section>
       
-      <section title="HTTP Redirects">
+      <section title="HTTP Redirects" anchor="sctn-http-redir">
 	<t>When a Token Consumer redirects the client to a Token Provider as a means to deliver the token
 	request, it SHOULD include a Include-Referred-Token-Binding-ID HTTP response header field in its
 	HTTP response. The ABNF of the Include-Referred-Token-Binding-ID header is (in <xref

--- a/draft-ietf-tokbind-https-04.xml
+++ b/draft-ietf-tokbind-https-04.xml
@@ -286,15 +286,7 @@
       server than the one that the TokenBindingMessage is sent
       to. This is useful in federation scenarios.</t>
 
-      <section title="Terminology">
-        <t>The following terms are defined in 
-        <xref target="I-D.ietf-tokbind-protocol"/>: 
-        TokenBinding, 
-        TokenBindingID ("Token Binding ID"),
-        TokenBindingMessage, 
-        TokenBindingType
-        </t>
-
+      <section title="Requirements Language">
         <t>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
         "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
         document are to be interpreted as described in <xref target="RFC2119" />.</t>


### PR DESCRIPTION
This initial set of commits comprises some minor editorial cleanups of wording and how citations are manifested, and  fixes #43, fixes #44, begins work on #45. 

I may add further commits this evening. 
