### PR TITLE
OAuth is authorization protocol 

### DIFF
--- a/draft-ietf-tokbind-https-08.xml
+++ b/draft-ietf-tokbind-https-08.xml
@@ -222,7 +222,7 @@
 
     <abstract>
       <t>This document describes a collection of mechanisms that allow
-      HTTP servers to cryptographically bind authentication tokens
+      HTTP servers to cryptographically bind authentication or authorization tokens
       (such as cookies and OAuth tokens) to <xref
       target="RFC5246">TLS</xref> connections.</t>
 


### PR DESCRIPTION
and problems have arisen from misusing it for authentication (see https://oauth.net/articles/authentication/ for example). While this is a bit of nit, I worry that wording like “... to cryptographically bind authentication tokens (such as cookies and OAuth tokens) to ..." in the HTTPSTB abstract might contribute to the misconception. This commit just adds "or authorization" to the sentence in the abstract.