### PR TITLE
Re: HTTPSTB: 'TB key' terminology cleanup, see #87 

### DIFF
--- a/draft-ietf-tokbind-https-08.xml
+++ b/draft-ietf-tokbind-https-08.xml
@@ -1197,6 +1197,8 @@ contexts. Other approaches are possible, but are outside the scope of this speci
       v08 2016-12-06  Jeff Hodges    Init -08.
       v08 2016-12-06  Jeff Hodges    Add explanation of splitting across renego boundaries.
       v08 2016-12-14  Jeff Hodges    Various editorial cleanups.
+      v08 2017-01-31  Jeff Hodges    'TB key' terminology cleanup, see #87 
+      v08 2017-02-06  Jeff Hodges    Andrei-Popov review fixups.
     -->
   </back>
 </rfc>

--- a/draft-ietf-tokbind-https-08.xml
+++ b/draft-ietf-tokbind-https-08.xml
@@ -250,10 +250,10 @@
     <section title="Introduction">
       <t><xref target="I-D.ietf-tokbind-protocol">The Token Binding Protocol</xref>
       defines a Token Binding ID for a TLS connection between a client
-      and a server. The Token Binding ID of a TLS connection is constructed using
-      the public key of a private-public key pair, of which
-      the client proves possession of the private key to
-      the server. This Token Binding key pair is long-lived 
+      and a server. The Token Binding ID of a TLS connection is constructed using the
+      public key of a private-public key pair.
+      The client proves possession of the corresponding private key.
+      This Token Binding key pair is long-lived
       (i.e., subsequent TLS connections
       between the same client and server have the same Token Binding
       ID, unless specifically reset, e.g., by the user). 
@@ -969,8 +969,8 @@ contexts. Other approaches are possible, but are outside the scope of this speci
         <t>
           Therefore, the Sec-Token-Binding header field in the federated sign-on use case
           contains both: a proof of possession of the provided Token Binding
-          ID, as well as a proof of possession of the referred Token Binding
-          ID.
+          key, as well as a proof of possession of the referred Token Binding
+          key.
         </t>
       </section>
     </section>


### PR DESCRIPTION
address some of Andrei's comments. 