### PR TITLE
HTTPSTB-editorial: fix typo

### DIFF
--- a/draft-ietf-tokbind-https-12.xml
+++ b/draft-ietf-tokbind-https-12.xml
@@ -531,7 +531,7 @@
        | TBMSG[[provided_token_binding,                       |
        |        TBID2, signature],                            |
        |       [referred_token_binding,                       |
-       |        TBID1, sognature]]                            |
+       |        TBID1, signature]]                            |
        |----------------------------------------------------->|
        |                                                      |
        |                               |                      |


### PR DESCRIPTION
This is editorial, fixes a minor typo "sognature".